### PR TITLE
Run webprotege-keycloak image to apply the new login theme UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
 
   keycloak:
-    image: keycloak/keycloak:26.1
+    image: protegeproject/webprotege-keycloak:1.1.0
     command: [ "start-dev" ]
     ports:
       - 8080:8080

--- a/keycloak/webprotege.json
+++ b/keycloak/webprotege.json
@@ -1280,7 +1280,7 @@
         "request.object.encryption.alg": "any",
         "client.introspection.response.allow.jwt.claim.enabled": "false",
         "saml.encrypt": "false",
-        "login_theme": "webprotege.v2",
+        "login_theme": "webprotege",
         "saml.server.signature": "false",
         "exclude.session.state.from.auth.response": "false",
         "saml.artifact.binding": "false",
@@ -1944,10 +1944,10 @@
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
   "smtpServer": {},
-  "loginTheme": "webprotege.v2",
+  "loginTheme": "webprotege",
   "accountTheme": "keycloak.v3",
   "adminTheme": "keycloak.v2",
-  "emailTheme": "webprotege.v2",
+  "emailTheme": "webprotege",
   "eventsEnabled": true,
   "eventsListeners": [
     "jboss-logging"


### PR DESCRIPTION
@matthewhorridge You will need to publish `webprotege-keycloak` to DockerHub (tag `v1.1.0`) before running the docker-compose.