### PR TITLE
Fix stale-tree bug: switch websocket URL to ws://

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       minio.endPoint: http://minio:9000
       KEYCLOAK_AUTH_URL: http://${SERVER_HOST}/keycloak/
       webprotege.gwt-api-gateway.endPoint: http://webprotege-gwt-api-gateway:7777
-      webprotege.websocketUrl: wss://${SERVER_HOST}/wsapps
+      webprotege.websocketUrl: ws://${SERVER_HOST}/wsapps
       webprotege.logoutUrl: http://${SERVER_HOST}/webprotege/logout
       webprotege.fileUploadurl: http://${SERVER_HOST}
       webprotege.keycloakLogoutUrl: http://${SERVER_HOST}/keycloak/realms/webprotege/protocol/openid-connect/logout


### PR DESCRIPTION
## Summary

- One-line fix in `docker-compose.yml`: `webprotege.websocketUrl` from `wss://${SERVER_HOST}/wsapps` to `ws://${SERVER_HOST}/wsapps`.
- The stack only serves plain HTTP on port 80 (no TLS listener, no certificate), so the TLS WebSocket handshake was failing silently.
- Short-term fix only — the long-term move to HTTPS + wss:// is tracked in #64.

## Why this fixes the stale-tree bug

`DefaultCreateEntitiesPresenter` in the GWT UI waits on `ChangeRequestEventAwaiter` for the hierarchy-changed event over the WebSocket before firing the tree-refresh callback. When the `wss://` handshake failed, no events reached the browser, so the tree stayed stale after any create (subclass, object property, data property, annotation property, named individual) until a manual page refresh loaded it fresh via HTTP.

Aligning the scheme with the rest of the stack (which is all `http://`) restores real-time updates.

## Test plan

- [ ] `docker compose up -d webprotege-gwt-ui-server` after pulling this branch.
- [ ] Hard-refresh the WebProtege page in the browser (the GWT bundle may be cached).
- [ ] DevTools → Network → WS: confirm a `101 Switching Protocols` response on `ws://${SERVER_HOST}/wsapps` with no `onWebSocketError` / `onStompError` messages in the console.
- [ ] Create a subclass in an ontology → new node appears in the class hierarchy immediately (no refresh).
- [ ] Create a new object / data / annotation property → new node appears in the property hierarchy immediately.
- [ ] Keycloak login + logout still round-trip.

## Related

Long-term HTTPS/WSS support tracked in #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)