### PR TITLE
Drop the websocket settings nothing reads anymore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,6 @@ services:
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: http://webprotege-keycloak:8080/keycloak/realms/webprotege/protocol/openid-connect/certs
       spring.servlet.multipart.max-file-size: 300MB
       spring.servlet.multipart.max-request-size: 300MB
-      WEBPROTEGE_ALLOWEDORIGIN: http://${SERVER_HOST}
       webprotege.rabbit.timeout: 600000
       _JAVA_OPTIONS: ${ENABLE_JAVA_DEBUG:+-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008}
     logging:
@@ -133,7 +132,6 @@ services:
       minio.endPoint: http://minio:9000
       KEYCLOAK_AUTH_URL: http://${SERVER_HOST}/keycloak/
       webprotege.gwt-api-gateway.endPoint: http://webprotege-gwt-api-gateway:7777
-      webprotege.websocketUrl: ws://${SERVER_HOST}/wsapps
       webprotege.logoutUrl: http://${SERVER_HOST}/webprotege/logout
       webprotege.fileUploadurl: http://${SERVER_HOST}
       webprotege.keycloakLogoutUrl: http://${SERVER_HOST}/keycloak/realms/webprotege/protocol/openid-connect/logout


### PR DESCRIPTION
The deploy half of protegeproject/webprotege-gwt-ui#308. The client receives events over SSE on the `/data/` route (protegeproject/webprotege-gwt-ui#317), the gateway no longer has a websocket endpoint or the allowed-origin setting (protegeproject/webprotege-gwt-api-gateway#52), and nginx no longer proxies `/wsapps` (protegeproject/webprotege-nginx#1, released as 2.0.3). The env lines are dead config; the image pins move on their own through the release automation.