### PR TITLE
Adopt the websocket-free nginx image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,7 +329,7 @@ services:
     - webprotege-data-directory:/srv/webprotege
 
   webprotege-nginx:
-    image: protegeproject/webprotege-nginx:2.0.2
+    image: protegeproject/webprotege-nginx:2.0.3
     hostname: ${SERVER_HOST}
     ports:
       - 80:80


### PR DESCRIPTION
nginx 2.0.3 (protegeproject/webprotege-nginx#1) drops the dead `/wsapps` proxy route retired with the WebSocket stack in protegeproject/webprotege-gwt-ui#308. The release automation bumped the app images but not this one.